### PR TITLE
Add initial relationship mapping app scaffold (FastAPI backend + React web + Expo mobile)

### DIFF
--- a/relaciones_app/backend/app/crud.py
+++ b/relaciones_app/backend/app/crud.py
@@ -1,0 +1,80 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import or_
+
+from . import models, schemas
+
+
+def get_people(db: Session, search: str | None = None):
+    query = db.query(models.Person)
+    if search:
+        like = f"%{search.lower()}%"
+        query = query.filter(
+            or_(
+                models.Person.nombre.ilike(like),
+                models.Person.external_id.ilike(like),
+            )
+        )
+    return query.order_by(models.Person.nombre.asc()).all()
+
+
+def upsert_person(db: Session, person: schemas.PersonCreate):
+    existing = db.query(models.Person).filter_by(external_id=person.external_id).first()
+    if existing:
+        existing.nombre = person.nombre
+        existing.curso = person.curso
+        existing.seccion = person.seccion
+        existing.foto_url = person.foto_url
+        db.add(existing)
+        db.commit()
+        db.refresh(existing)
+        return existing
+    new_person = models.Person(**person.model_dump())
+    db.add(new_person)
+    db.commit()
+    db.refresh(new_person)
+    return new_person
+
+
+def normalize_pair(persona_a_id: int, persona_b_id: int) -> tuple[int, int]:
+    if persona_a_id == persona_b_id:
+        raise ValueError("No se permiten relaciones con la misma persona")
+    return (persona_a_id, persona_b_id) if persona_a_id < persona_b_id else (persona_b_id, persona_a_id)
+
+
+def upsert_relationship(db: Session, rel: schemas.RelationshipCreate):
+    a_id, b_id = normalize_pair(rel.persona_a_id, rel.persona_b_id)
+    existing = (
+        db.query(models.Relationship)
+        .filter_by(persona_a_id=a_id, persona_b_id=b_id)
+        .first()
+    )
+    if existing:
+        existing.tipo = rel.tipo
+        existing.activo = True
+        db.add(existing)
+        db.commit()
+        db.refresh(existing)
+        return existing
+    new_rel = models.Relationship(
+        persona_a_id=a_id,
+        persona_b_id=b_id,
+        tipo=rel.tipo,
+        activo=True,
+    )
+    db.add(new_rel)
+    db.commit()
+    db.refresh(new_rel)
+    return new_rel
+
+
+def list_relationships_for_person(db: Session, person_id: int):
+    return (
+        db.query(models.Relationship)
+        .filter(
+            or_(
+                models.Relationship.persona_a_id == person_id,
+                models.Relationship.persona_b_id == person_id,
+            )
+        )
+        .all()
+    )

--- a/relaciones_app/backend/app/database.py
+++ b/relaciones_app/backend/app/database.py
@@ -1,0 +1,12 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///./relaciones.db"
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False},
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/relaciones_app/backend/app/main.py
+++ b/relaciones_app/backend/app/main.py
@@ -1,0 +1,88 @@
+from fastapi import FastAPI, Depends, UploadFile, File, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy.orm import Session
+import csv
+from io import StringIO
+
+from .database import SessionLocal, engine
+from . import models, schemas, crud
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Mapa de Relaciones")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"]
+    ,
+    allow_credentials=True,
+    allow_methods=["*"] ,
+    allow_headers=["*"],
+)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}
+
+
+@app.get("/people", response_model=list[schemas.Person])
+def list_people(search: str | None = None, db: Session = Depends(get_db)):
+    return crud.get_people(db, search=search)
+
+
+@app.post("/relationships", response_model=schemas.Relationship)
+def create_relationship(rel: schemas.RelationshipCreate, db: Session = Depends(get_db)):
+    try:
+        return crud.upsert_relationship(db, rel)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/relationships", response_model=list[schemas.Relationship])
+def list_relationships(person_id: int, db: Session = Depends(get_db)):
+    return crud.list_relationships_for_person(db, person_id)
+
+
+@app.post("/admin/import-csv")
+def import_csv(file: UploadFile = File(...), db: Session = Depends(get_db)):
+    content = file.file.read().decode("utf-8")
+    reader = csv.DictReader(StringIO(content))
+    required_fields = {"id", "nombre", "curso", "seccion", "foto_url"}
+    if not required_fields.issubset(reader.fieldnames or []):
+        raise HTTPException(
+            status_code=400,
+            detail=f"CSV debe contener columnas: {', '.join(sorted(required_fields))}",
+        )
+
+    created = 0
+    updated = 0
+    errors = []
+    for idx, row in enumerate(reader, start=2):
+        try:
+            person = schemas.PersonCreate(
+                external_id=row["id"].strip(),
+                nombre=row["nombre"].strip(),
+                curso=row["curso"].strip(),
+                seccion=row.get("seccion", "").strip() or None,
+                foto_url=row.get("foto_url", "").strip() or None,
+            )
+        except Exception as exc:
+            errors.append({"row": idx, "error": str(exc)})
+            continue
+        existing = db.query(models.Person).filter_by(external_id=person.external_id).first()
+        crud.upsert_person(db, person)
+        if existing:
+            updated += 1
+        else:
+            created += 1
+
+    return {"created": created, "updated": updated, "errors": errors}

--- a/relaciones_app/backend/app/models.py
+++ b/relaciones_app/backend/app/models.py
@@ -1,0 +1,34 @@
+from sqlalchemy import Boolean, Column, Integer, String, Enum, UniqueConstraint
+from sqlalchemy.orm import relationship
+import enum
+
+from .database import Base
+
+
+class RelationType(str, enum.Enum):
+    amistad = "amistad"
+    amistad_fuerte = "amistad_fuerte"
+
+
+class Person(Base):
+    __tablename__ = "personas"
+
+    id = Column(Integer, primary_key=True, index=True)
+    external_id = Column(String, unique=True, index=True, nullable=False)
+    nombre = Column(String, nullable=False)
+    curso = Column(String, nullable=False)
+    seccion = Column(String, nullable=True)
+    foto_url = Column(String, nullable=True)
+
+
+class Relationship(Base):
+    __tablename__ = "relaciones"
+    __table_args__ = (
+        UniqueConstraint("persona_a_id", "persona_b_id", name="uq_relacion_par"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    persona_a_id = Column(Integer, nullable=False, index=True)
+    persona_b_id = Column(Integer, nullable=False, index=True)
+    tipo = Column(Enum(RelationType), nullable=False)
+    activo = Column(Boolean, default=True, nullable=False)

--- a/relaciones_app/backend/app/schemas.py
+++ b/relaciones_app/backend/app/schemas.py
@@ -1,0 +1,43 @@
+from pydantic import BaseModel, HttpUrl
+from typing import Optional, List
+
+
+class PersonBase(BaseModel):
+    external_id: str
+    nombre: str
+    curso: str
+    seccion: Optional[str] = None
+    foto_url: Optional[HttpUrl] = None
+
+
+class PersonCreate(PersonBase):
+    pass
+
+
+class Person(PersonBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
+class RelationshipBase(BaseModel):
+    persona_a_id: int
+    persona_b_id: int
+    tipo: str
+
+
+class RelationshipCreate(RelationshipBase):
+    pass
+
+
+class Relationship(RelationshipBase):
+    id: int
+    activo: bool
+
+    class Config:
+        from_attributes = True
+
+
+class RelationshipList(BaseModel):
+    relaciones: List[Relationship]

--- a/relaciones_app/backend/requirements.txt
+++ b/relaciones_app/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+sqlalchemy==2.0.35
+pydantic==2.9.2

--- a/relaciones_app/mobile/App.js
+++ b/relaciones_app/mobile/App.js
@@ -1,0 +1,170 @@
+import { useEffect, useState } from 'react'
+import { SafeAreaView, Text, View, StyleSheet, TextInput, TouchableOpacity, Alert } from 'react-native'
+import { StatusBar } from 'expo-status-bar'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:8000'
+
+export default function App() {
+  const [search, setSearch] = useState('')
+  const [people, setPeople] = useState([])
+  const [personA, setPersonA] = useState(null)
+  const [personB, setPersonB] = useState(null)
+  const [relationType, setRelationType] = useState('amistad')
+
+  useEffect(() => {
+    fetch(`${API_URL}/people?search=${encodeURIComponent(search)}`)
+      .then((response) => response.json())
+      .then((data) => setPeople(data))
+      .catch(() => setPeople([]))
+  }, [search])
+
+  const handleSave = async () => {
+    if (!personA || !personB) {
+      Alert.alert('Selecciona ambas personas antes de guardar')
+      return
+    }
+    const response = await fetch(`${API_URL}/relationships`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        persona_a_id: personA.id,
+        persona_b_id: personB.id,
+        tipo: relationType
+      })
+    })
+    if (!response.ok) {
+      const error = await response.json()
+      Alert.alert(error.detail || 'No se pudo guardar la relación')
+      return
+    }
+    Alert.alert('Relación guardada')
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <StatusBar style="dark" />
+      <Text style={styles.title}>Mapa de Relaciones</Text>
+      <Text style={styles.subtitle}>Declara relaciones bidireccionales entre estudiantes.</Text>
+
+      <TextInput
+        style={styles.input}
+        placeholder="Buscar estudiante"
+        value={search}
+        onChangeText={setSearch}
+      />
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Persona A</Text>
+        {people.slice(0, 5).map((person) => (
+          <TouchableOpacity
+            key={`a-${person.id}`}
+            style={[styles.option, personA?.id === person.id && styles.optionSelected]}
+            onPress={() => setPersonA(person)}
+          >
+            <Text>{person.nombre}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Persona B</Text>
+        {people.slice(0, 5).map((person) => (
+          <TouchableOpacity
+            key={`b-${person.id}`}
+            style={[styles.option, personB?.id === person.id && styles.optionSelected]}
+            onPress={() => setPersonB(person)}
+          >
+            <Text>{person.nombre}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Tipo de relación</Text>
+        <View style={styles.row}>
+          <TouchableOpacity
+            style={[styles.tag, relationType === 'amistad' && styles.tagSelected]}
+            onPress={() => setRelationType('amistad')}
+          >
+            <Text>Amistad</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.tag, relationType === 'amistad_fuerte' && styles.tagSelected]}
+            onPress={() => setRelationType('amistad_fuerte')}
+          >
+            <Text>Amistad fuerte</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
+        <Text style={styles.saveText}>Guardar relación</Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#f5f7fa'
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700'
+  },
+  subtitle: {
+    marginTop: 4,
+    color: '#52606d'
+  },
+  input: {
+    marginTop: 16,
+    padding: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#cbd2d9',
+    backgroundColor: '#fff'
+  },
+  section: {
+    marginTop: 16
+  },
+  label: {
+    fontWeight: '600',
+    marginBottom: 8
+  },
+  option: {
+    padding: 10,
+    borderRadius: 8,
+    backgroundColor: '#fff',
+    marginBottom: 8
+  },
+  optionSelected: {
+    borderWidth: 1,
+    borderColor: '#2563eb'
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 10
+  },
+  tag: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 999,
+    backgroundColor: '#e2e8f0'
+  },
+  tagSelected: {
+    backgroundColor: '#bfdbfe'
+  },
+  saveButton: {
+    marginTop: 24,
+    backgroundColor: '#2563eb',
+    padding: 14,
+    borderRadius: 999,
+    alignItems: 'center'
+  },
+  saveText: {
+    color: '#fff',
+    fontWeight: '600'
+  }
+})

--- a/relaciones_app/mobile/app.json
+++ b/relaciones_app/mobile/app.json
@@ -1,0 +1,8 @@
+{
+  "expo": {
+    "name": "Mapa de Relaciones",
+    "slug": "relaciones-mobile",
+    "version": "0.1.0",
+    "sdkVersion": "51.0.0"
+  }
+}

--- a/relaciones_app/mobile/package.json
+++ b/relaciones_app/mobile/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "relaciones-mobile",
+  "private": true,
+  "version": "0.1.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^51.0.0",
+    "expo-status-bar": "~1.12.1",
+    "react": "18.2.0",
+    "react-native": "0.74.3"
+  }
+}

--- a/relaciones_app/web/index.html
+++ b/relaciones_app/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mapa de Relaciones</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/relaciones_app/web/package.json
+++ b/relaciones_app/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "relaciones-web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "vite": "^5.4.5"
+  }
+}

--- a/relaciones_app/web/src/App.jsx
+++ b/relaciones_app/web/src/App.jsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState } from 'react'
+import { createRelationship, fetchPeople } from './api'
+import './styles.css'
+
+const RELATION_TYPES = [
+  { value: 'amistad', label: 'Amistad' },
+  { value: 'amistad_fuerte', label: 'Amistad fuerte' }
+]
+
+export default function App() {
+  const [people, setPeople] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [personA, setPersonA] = useState('')
+  const [personB, setPersonB] = useState('')
+  const [relationType, setRelationType] = useState('amistad')
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    let isMounted = true
+    setLoading(true)
+    fetchPeople(search)
+      .then((data) => {
+        if (isMounted) {
+          setPeople(data)
+        }
+      })
+      .catch((error) => {
+        if (isMounted) {
+          setMessage(error.message)
+        }
+      })
+      .finally(() => {
+        if (isMounted) {
+          setLoading(false)
+        }
+      })
+    return () => {
+      isMounted = false
+    }
+  }, [search])
+
+  const peopleOptions = useMemo(
+    () => people.map((person) => ({ value: person.id, label: `${person.nombre} (${person.curso})` })),
+    [people]
+  )
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    setMessage('')
+    if (!personA || !personB) {
+      setMessage('Selecciona ambas personas antes de guardar')
+      return
+    }
+    try {
+      await createRelationship({
+        persona_a_id: Number(personA),
+        persona_b_id: Number(personB),
+        tipo: relationType
+      })
+      setMessage('Relación guardada correctamente')
+    } catch (error) {
+      setMessage(error.message)
+    }
+  }
+
+  return (
+    <div className="container">
+      <header>
+        <h1>Mapa de Relaciones</h1>
+        <p>Declara relaciones bidireccionales entre estudiantes.</p>
+      </header>
+
+      <section className="panel">
+        <div className="field">
+          <label htmlFor="search">Buscar estudiante</label>
+          <input
+            id="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Nombre o ID"
+          />
+        </div>
+
+        {loading ? (
+          <p className="muted">Cargando estudiantes...</p>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <div className="grid">
+              <div className="field">
+                <label>Persona A</label>
+                <select value={personA} onChange={(event) => setPersonA(event.target.value)}>
+                  <option value="">Selecciona</option>
+                  {peopleOptions.map((person) => (
+                    <option key={`a-${person.value}`} value={person.value}>
+                      {person.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="field">
+                <label>Persona B</label>
+                <select value={personB} onChange={(event) => setPersonB(event.target.value)}>
+                  <option value="">Selecciona</option>
+                  {peopleOptions.map((person) => (
+                    <option key={`b-${person.value}`} value={person.value}>
+                      {person.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="field">
+              <label>Tipo de relación</label>
+              <select value={relationType} onChange={(event) => setRelationType(event.target.value)}>
+                {RELATION_TYPES.map((type) => (
+                  <option key={type.value} value={type.value}>
+                    {type.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <button type="submit">Guardar relación</button>
+          </form>
+        )}
+
+        {message && <p className="message">{message}</p>}
+      </section>
+    </div>
+  )
+}

--- a/relaciones_app/web/src/api.js
+++ b/relaciones_app/web/src/api.js
@@ -1,0 +1,26 @@
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+export async function fetchPeople(search = '') {
+  const url = new URL(`${API_URL}/people`)
+  if (search) {
+    url.searchParams.set('search', search)
+  }
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error('No se pudo cargar la lista de personas')
+  }
+  return response.json()
+}
+
+export async function createRelationship(payload) {
+  const response = await fetch(`${API_URL}/relationships`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(error.detail || 'No se pudo guardar la relación')
+  }
+  return response.json()
+}

--- a/relaciones_app/web/src/main.jsx
+++ b/relaciones_app/web/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/relaciones_app/web/src/styles.css
+++ b/relaciones_app/web/src/styles.css
@@ -1,0 +1,74 @@
+:root {
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #1f2933;
+  background-color: #f5f7fa;
+}
+
+body {
+  margin: 0;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+header {
+  margin-bottom: 1.5rem;
+}
+
+.panel {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.field {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+label {
+  font-weight: 600;
+}
+
+input,
+select {
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #cbd2d9;
+  font-size: 0.95rem;
+}
+
+button {
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #1d4ed8;
+}
+
+.message {
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.muted {
+  color: #52606d;
+}

--- a/relaciones_app/web/vite.config.js
+++ b/relaciones_app/web/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})


### PR DESCRIPTION
### Motivation
- Provide a minimal scaffold to map bidirectional student relationships with CSV import and a small local database.
- Offer both web (React + Vite) and mobile (Expo React Native) frontends to declare and submit relationships to the API.
- Ensure upsert semantics for people and relationships and avoid duplicate inverse relations by normalizing pairs in the backend.
- Make it easy to run the app locally with a SQLite backend and simple REST endpoints.

### Description
- Add backend files (`database.py`, `models.py`, `schemas.py`, `crud.py`, `main.py`, `requirements.txt`) implementing `Person` and `Relationship` models and endpoints `/people`, `/relationships` and `/admin/import-csv`.
- Implement normalization and upsert logic in `crud.py` through `normalize_pair`, `upsert_person`, and `upsert_relationship`, and enforce a unique pair constraint on relationships.
- Add a React web scaffold under `relaciones_app/web` (Vite + React) including `web/src/api.js`, `web/src/App.jsx`, `web/src/main.jsx`, styles and Vite config to interact with the API.
- Add an Expo React Native starter under `relaciones_app/mobile` with `App.js`, `package.json`, and `app.json` to serve as a mobile entry point.

### Testing
- Attempted to install backend dependencies with `python -m pip install -r relaciones_app/backend/requirements.txt`, but the command failed due to network/proxy restrictions.
- No automated tests or runtime verification were executed because dependency installation was blocked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955a1622bdc8331bdbea9aaac4ec510)